### PR TITLE
Fix "Too many open files" and blank world

### DIFF
--- a/mc3ds/classes.py
+++ b/mc3ds/classes.py
@@ -375,6 +375,7 @@ class DBDirectory:
         pass
 
     def __init__(self, path: str | bytes | os.PathLike) -> None:
+        self._cache = {}
         self._path = Path(path)
         self._reload_data()
 
@@ -413,7 +414,9 @@ class DBDirectory:
 
     def __getitem__(self, key: int) -> Any:
         path = self._files[key]
-        return self._process(open(path, "rb"))
+        if not path in self._cache:
+            self._cache[path] = self._process(open(path, "rb"))        
+        return self._cache[path]
 
 
 class CDBDirectory(DBDirectory):

--- a/mc3ds/convert.py
+++ b/mc3ds/convert.py
@@ -73,6 +73,7 @@ class ChunkConverter:
                                 )
                                 sys.stderr.flush()
                                 block = Block("minecraft", "netherite_block")
+                            self.chunk.set_block(block, x, calculated_y, z)
 
     @property
     def region_position(self) -> tuple[int, int, int]:


### PR DESCRIPTION
As the title says, I added a dict to DBDirectory class that acts as a cache, reusing already processed paths, avoiding opening files that are already open and avoiding the error "Too many open files" in OS like Ubuntu with an open file descriptors limit of 1024.

Also saw that a line was missing in the ChunkConverter.place_blocks method at the end that sets the current block in the chunk. That was the reason the latest converted worlds were empty (mentioned in MC3DS-Save-Research/3DS-Chunker#7 )